### PR TITLE
:construction_worker: Upgrade to ci/4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    tags:
+      - "*"
     branches:
       - main
   schedule:
@@ -11,11 +13,11 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@3.0.4
+    uses: libhal/ci/.github/workflows/library.yml@4.0.0
     secrets: inherit
 
   cortex-m3:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.4
+    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.0.0
     with:
       profile: stm32f103c8
       upload: true
@@ -23,14 +25,14 @@ jobs:
     secrets: inherit
 
   stm32f103c4:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.4
+    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.0.0
     with:
       profile: stm32f103c4
       processor_profile: https://github.com/libhal/libhal-armcortex.git
     secrets: inherit
 
   stm32f103zd:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@3.0.4
+    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.0.0
     with:
       profile: stm32f103zd
       processor_profile: https://github.com/libhal/libhal-armcortex.git


### PR DESCRIPTION
Uploads now require a new tag to be pushed to work. This will minimize the number of uploads and possible revisions pushed to artifactory to just releases. Allowing the main branch to change and only when a commit has a release candidate will a release be made.