### PR TITLE
:safety_vest: Add reset & count to uart example

### DIFF
--- a/demos/applications/uart.cpp
+++ b/demos/applications/uart.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <libhal-armcortex/dwt_counter.hpp>
+#include <libhal-armcortex/system_control.hpp>
 #include <libhal-stm32f1/clock.hpp>
 #include <libhal-stm32f1/constants.hpp>
 #include <libhal-stm32f1/uart.hpp>
@@ -25,12 +26,20 @@ void application()
   auto cpu_frequency = hal::stm32f1::frequency(hal::stm32f1::peripheral::cpu);
   hal::cortex_m::dwt_counter steady_clock(cpu_frequency);
   hal::stm32f1::uart uart1(hal::port<1>, hal::buffer<128>);
+  hal::print(uart1, "[stm32f1] Starting UART demo...\n");
+
+  int counter = 0;
 
   while (true) {
     using namespace std::chrono_literals;
     std::array<hal::byte, 64> read_buffer{};
-    hal::print(uart1, "Hello, World\n");
+    hal::print<32>(uart1, "Hello, World %d\n", counter++);
     hal::print(uart1, uart1.read(read_buffer).data);
     hal::delay(steady_clock, 500ms);
+
+    if (counter > 10) {
+      hal::print(uart1, "Resetting board...\n\n\n\n");
+      hal::cortex_m::reset();
+    }
   }
 }


### PR DESCRIPTION
This way we can test if the stm boards are able to reset or if there is an issue with the boot and reset pins.